### PR TITLE
Authentication improvements

### DIFF
--- a/coderdojochi/apps.py
+++ b/coderdojochi/apps.py
@@ -6,3 +6,7 @@ class CoderDojoChiConfig(AppConfig):
 
     def ready(self):
         import coderdojochi.signals_handlers
+        from .models import CDCUser
+
+        CDCUser._meta.get_field_by_name('email')[0]._unique = True
+        CDCUser.REQUIRED_FIELDS.remove('email')

--- a/coderdojochi/settings.py
+++ b/coderdojochi/settings.py
@@ -29,7 +29,6 @@ IS_PRODUCTION = not DEBUG
 
 ALLOWED_HOSTS = ['*']
 
-
 SITE_URL = 'http://localhost:8000'
 
 # Application definition
@@ -47,7 +46,7 @@ INSTALLED_APPS = (
 
     #vendor
     'registration',
-    'social_auth',
+    'social.apps.django_app.default',
     'avatar',
     'bootstrap3',
     'html5',
@@ -87,23 +86,16 @@ TEMPLATE_CONTEXT_PROCESSORS = (
 
     # coderdojochi
     'coderdojochi.context_processors.main_config_processor',
+
+    #vendor
+    'social.apps.django_app.context_processors.backends',
+    'social.apps.django_app.context_processors.login_redirect',
 )
 
-AUTHENTICATION_BACKENDS = (
-    'social_auth.backends.facebook.FacebookBackend',
-    'social_auth.backends.google.GoogleOAuth2Backend',
-    'django.contrib.auth.backends.ModelBackend',
-)
 
 ROOT_URLCONF = 'coderdojochi.urls'
 
 WSGI_APPLICATION = 'coderdojochi.wsgi.application'
-
-AUTH_USER_MODEL = 'coderdojochi.CDCUser'
-
-LOGIN_URL = '/accounts/login/'
-LOGOUT_URL = '/accounts/logout/'
-LOGIN_REDIRECT_URL = '/dojo/'
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
@@ -162,10 +154,36 @@ STATICFILES_DIRS = (
     os.path.join(PACKAGE_ROOT, 'static'),
 )
 
-# Registration
+
+AUTHENTICATION_BACKENDS = (
+    'social.backends.facebook.FacebookOAuth2',
+    'social.backends.google.GoogleOAuth2',
+    'django.contrib.auth.backends.ModelBackend',
+)
+
+AUTH_USER_MODEL = 'coderdojochi.CDCUser'
+
+LOGIN_URL = '/accounts/login/'
+LOGOUT_URL = '/accounts/logout/'
+LOGIN_REDIRECT_URL = '/dojo/'
+LOGIN_ERROR_URL = '/accounts/login/'
 
 ACCOUNT_ACTIVATION_DAYS = 7
-LOGIN_ERROR_URL = '/accounts/login/'
+
+SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = '294736693640-ejq5vqa2qpiciimnnn5v749aq4gppeic.apps.googleusercontent.com'
+SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = '_APcXgCWQjFULQq-ftNHK4_C'
+
+SOCIAL_AUTH_FACEBOOK_KEY = '1454178301519376'
+SOCIAL_AUTH_FACEBOOK_SECRET = '36edff0d6d4a9686647f76f2d0f511ed'
+SOCIAL_AUTH_FACEBOOK_SCOPE = ['email']
+
+SOCIAL_AUTH_USER_MODEL = 'coderdojochi.CDCUser'
+
+SOCIAL_AUTH_LOGIN_URL = LOGIN_URL
+SOCIAL_AUTH_LOGIN_REDIRECT_URL = LOGIN_REDIRECT_URL
+SOCIAL_AUTH_LOGIN_ERROR_URL = LOGIN_ERROR_URL
+
+SESSION_SERIALIZER='django.contrib.sessions.serializers.PickleSerializer'
 
 # Gravatar
 
@@ -177,17 +195,6 @@ AVATAR_DEFAULT_URL = 'http://www.gravatar.com/avatar/?s=350&d=mm'
 PAYPAL_RECEIVER_EMAIL = 'info@coderdojochi.org'
 PAYPAL_BUSINESS_ID = 'CXD22M5GNXDE4'
 PAYPAL_TEST = False
-
-# Social Auth
-
-GOOGLE_OAUTH2_CLIENT_ID = '294736693640-inucj2ptaap06iggukfurmqihblavbt8.apps.googleusercontent.com'
-GOOGLE_OAUTH2_CLIENT_SECRET = 'rgdutyo5mqCN7yOIMxET9hHv'
-GOOGLE_DISPLAY_NAME = 'CoderDojoChi'
-FACEBOOK_APP_ID = '1454178301519376'
-FACEBOOK_API_SECRET = '36edff0d6d4a9686647f76f2d0f511ed'
-SOCIAL_AUTH_USER_MODEL = 'coderdojochi.CDCUser'
-SOCIAL_AUTH_USERNAME_IS_FULL_EMAIL = True
-SESSION_SERIALIZER='django.contrib.sessions.serializers.PickleSerializer'
 
 
 # search for environment specific settings to override settings.py

--- a/coderdojochi/templates/registration/login.html
+++ b/coderdojochi/templates/registration/login.html
@@ -11,7 +11,7 @@
         <h1>Login</h1>
         <h2>{% trans "Not yet a member" %}? <a href="{% url 'register' %}">{% trans "Register now" %}</a>!</h2>
     </div>
-    <p><a class="btn login-google" href="/login/google-oauth2/">Sign in with Google</a></p>
+    <p><a class="btn login-google" href="{% url 'social:begin' "google-oauth2" %}">{% trans "Sign in with Google" %}</a></p>
     <p class="text-muted">or</p>
     <div class="row">
         <form method="post" action="." class="form">

--- a/coderdojochi/templates/registration/registration_form.html
+++ b/coderdojochi/templates/registration/registration_form.html
@@ -13,7 +13,7 @@
     </div>
     <div class="row">
         <div class="half">
-            <p><a class="btn signup-google" href="/login/google-oauth2/">{% trans "Sign up with Google" %}</a></p>
+            <p><a class="btn signup-google" href="{% url 'social:begin' "google-oauth2" %}">{% trans "Sign up with Google" %}</a></p>
         </div>
         <div class="half">
             <p><span class="btn signup-email">{% trans "Sign up with Email" %}</span></p>

--- a/coderdojochi/urls.py
+++ b/coderdojochi/urls.py
@@ -64,7 +64,7 @@ urlpatterns = patterns('',
     url(r'^login/$', auth_views.login, {'template_name': 'registration/login.html'}),
     url(r'^login/user/(?P<user_id>.+)/$', 'loginas.views.user_login', name='loginas-user-login'),
     url(r'^accounts/', include('registration.backends.default.urls')),
-    url(r'', include('social_auth.urls')),
+    url('', include('social.apps.django_app.urls', namespace='social')),
     url(r'^dj-admin/', include(admin.site.urls)),
     url(r'^avatar/', include('avatar.urls')),
 )

--- a/coderdojochi/views.py
+++ b/coderdojochi/views.py
@@ -54,13 +54,14 @@ class CDCRegistrationForm(registration_forms.RegistrationForm):
                                 widget=forms.HiddenInput,
                                 error_messages={'invalid': _("This value may contain only letters, numbers and @/./+/-/_ characters.")})
 
+
     def clean_email(self):
         """
         Validate that the username is alphanumeric and is not already
         in use.
 
         """
-        existing = User.objects.filter(username__iexact=self.cleaned_data['email'])
+        existing = User.objects.filter(email__iexact=self.cleaned_data['email'])
         if existing.exists():
             raise forms.ValidationError(_("A user with that email already exists."))
         else:
@@ -89,11 +90,11 @@ class RegisterView(RegistrationView):
     def register(self, request, **cleaned_data):
 
         email, password, first_name, last_name = cleaned_data['email'], cleaned_data['password1'], cleaned_data['first_name'].strip(), cleaned_data['last_name'].strip()
-        username = email
+        username = email[:30]
 
         user = User.objects.create_user(username, email, password, first_name=first_name, last_name=last_name)
 
-        new_user = authenticate(username=username, password=password)
+        new_user = authenticate(username=email, password=password)
         login(request, new_user)
         signals.user_registered.send(sender=self.__class__,
                                      user=new_user,

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,16 +10,16 @@ django-html5==1.0.0
 django-loginas==0.1.5
 django-paypal==0.2
 -e git+http://github.com/CoderDojoChi/django-registration.git@ec1c33220c71d07ae303d1206125e043bc36a09f#egg=django_registration-master
-django-social-auth==0.7.28
 djrill==1.2.0
 httplib2==0.9
 icalendar==3.9.0
-oauth2==1.5.211
 psycopg2==2.5.1
 python-dateutil==2.4.0
 python-memcached==1.54
 python-openid==2.2.5
+python-social-auth==0.2.9
 pytz==2014.4
 requests==2.5.0
+requests_oauthlib==0.5.0
 six==1.7.2
 wsgiref==0.1.2


### PR DESCRIPTION
Based on #185 

> This became a pretty big set of changes quickly...
> 
> - truly leverage email field as username via custom user manager
> - now allows for 75 character email username rather than only 30 previously
> - went from django-social-auth (deprecated) to python-social-auth
> - re-enable facebook auth
> - This one we should merge together, will require migrations and I think we need to update some settings on the google and facebook sides.