### PR TITLE
Class reminder emails not sending

### DIFF
--- a/coderdojochi/cron.py
+++ b/coderdojochi/cron.py
@@ -22,7 +22,7 @@ class SendReminders(CronJobBase):
         orders_within_a_week = Order.objects.filter(active=True, week_reminder_sent=False, session__start_date__lte=timezone.now() + datetime.timedelta(days=7), session__start_date__gte=timezone.now() + datetime.timedelta(days=1))
         orders_within_a_day = Order.objects.filter(active=True, day_reminder_sent=False, session__start_date__lte=timezone.now() + datetime.timedelta(days=1), session__start_date__gte=timezone.now() - datetime.timedelta(days=2))
         sessions_within_a_week = Session.objects.filter(active=True, mentors_week_reminder_sent=False, start_date__lte=timezone.now() + datetime.timedelta(days=7), start_date__gte=timezone.now() + datetime.timedelta(days=1))
-        sessions_within_a_day = Session.objects.filter(active=True, mentors_day_reminder_sent=False, start_date__lte=timezone.now() + datetime.timedelta(days=1), session__start_date__gte=timezone.now() - datetime.timedelta(days=2))
+        sessions_within_a_day = Session.objects.filter(active=True, mentors_day_reminder_sent=False, start_date__lte=timezone.now() + datetime.timedelta(days=1), start_date__gte=timezone.now() - datetime.timedelta(days=2))
 
         for order in orders_within_a_week:
             sendSystemEmail(order.guardian.user, 'Upcoming class reminder', 'coderdojochi-class-reminder-guardian', {


### PR DESCRIPTION
#204 

There is a errand filter on the query within the cron task.  Seems like no class reminders have gone out since Mar 29 which is about what it looks like in Mandrill.  Sucks, oversight on my part but this should get them working.

**NOTE:**  Before we deploy this we should update all the email statuses for any past orders/session as sent so the old one's dont go out (we can do this easily via the django shell)

