### PR TITLE
Canceled orders showing up in Dojo

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 DEBUG=True
 
-SITE_URL=http://coderdojochi.org
+SITE_URL=http://192.168.99.100
 
 # Database
 POSTGRES_HOST=db

--- a/coderdojochi/views.py
+++ b/coderdojochi/views.py
@@ -809,11 +809,10 @@ def dojo(request, template_name="dojo.html"):
     }
 
     if request.user.role:
-
         if request.user.role == 'mentor':
             mentor = get_object_or_404(Mentor, user=request.user)
             account = mentor
-            mentor_sessions = Session.objects.filter(id__in=MentorOrder.objects.filter(mentor=mentor).values('session__id'))
+            mentor_sessions = Session.objects.filter(id__in=MentorOrder.objects.filter(mentor=mentor, active=True).values('session__id'))
 
             upcoming_sessions = mentor_sessions.filter(
                 active=True,


### PR DESCRIPTION
https://github.com/CoderDojoChi/coderdojochi/issues/342

- update SITE_URL to http://192.168.99.100 for local dev
- ensure session orders displayed to mentors are `active=True`