### PR TITLE
Added STATIC_URL to context processor

### DIFF
--- a/coderdojochi/context_processors.py
+++ b/coderdojochi/context_processors.py
@@ -6,5 +6,6 @@ from django.conf import settings
 def main_config_processor(request):
     return {
         'SITE_URL': settings.SITE_URL,
-        'DEBUG': settings.DEBUG
+        'DEBUG': settings.DEBUG,
+        'STATIC_URL': settings.STATIC_URL,
     }

--- a/coderdojochi/templates/404.html
+++ b/coderdojochi/templates/404.html
@@ -23,7 +23,7 @@
 				bottom: 10px;
 				height: 150px;
 				width: 100%;
-				background-image: url({{ settings.STATIC_URL }}images/coderdojochi_600x300_transparent.png);
+				background-image: url({{ STATIC_URL }}images/coderdojochi_600x300_transparent.png);
 			    background-repeat: no-repeat;
 			    background-position: left bottom;
 			    background-size: 300px 150px;

--- a/coderdojochi/templates/home.html
+++ b/coderdojochi/templates/home.html
@@ -54,7 +54,7 @@
 {% if upcoming_classes %}
 <div class="upcoming-sessions">
     {% for session in upcoming_classes %}
-        <div class="upcoming-session" style="background-image: url({% if session.bg_image %}{{ session.bg_image.url }}{% else %}{{ settings.STATIC_URL }}images/{{ session.image_url }}{% endif %});">
+        <div class="upcoming-session" style="background-image: url({% if session.bg_image %}{{ session.bg_image.url }}{% else %}{{ STATIC_URL }}images/{{ session.image_url }}{% endif %});">
             <div class="session-shim">
                 <div class="container">
                     <div class="date">

--- a/coderdojochi/templates/sessions.html
+++ b/coderdojochi/templates/sessions.html
@@ -25,7 +25,7 @@
 <div class="upcoming-sessions">
 {% if all_sessions %}
     {% for session in all_sessions %}
-        <div class="upcoming-session" style="background-image: url({% if session.bg_image %}{{ session.bg_image.url }}{% else %}{{ settings.STATIC_URL }}images/{{ session.image_url }}{% endif %});">
+        <div class="upcoming-session" style="background-image: url({% if session.bg_image %}{{ session.bg_image.url }}{% else %}{{ STATIC_URL }}images/{{ session.image_url }}{% endif %});">
             <div class="session-shim">
                 <div class="container">
                     <div class="date">

--- a/coderdojochi/views.py
+++ b/coderdojochi/views.py
@@ -229,7 +229,6 @@ def sessions(request, year=False, month=False, template_name="sessions.html"):
         'calendar_date': calendar_date,
         'prev_date': prev_date,
         'next_date': next_date,
-        'settings': settings
     })
 
 
@@ -1061,7 +1060,6 @@ def donate(request, template_name="donate.html"):
     form = PayPalPaymentsForm(initial=paypal_dict)
 
     return render(request, template_name, {
-        'site_url': settings.SITE_URL,
         'form': form
     })
 


### PR DESCRIPTION
Since the `settings.STATIC_URL` variable was being used in multiple pages and sometimes missed in adding in the views.py, I've added the variable to the context processor. This allows the use of `STATIC_URL` in any template file.