### PR TITLE
Fixed missed changes from guardian/mentor to user

### DIFF
--- a/coderdojochi/models.py
+++ b/coderdojochi/models.py
@@ -313,18 +313,18 @@ class Session(models.Model):
                 orders = MentorOrder.objects.filter(
                     active=True,
                     session=self
-                ).exclude(check_in=None).order_by('mentor__last_name')
+                ).exclude(check_in=None).order_by('mentor__user__last_name')
             else:
                 orders = MentorOrder.objects.filter(
                     active=True,
                     session=self,
                     check_in=None
-                ).order_by('mentor__last_name')
+                ).order_by('mentor__user__last_name')
         else:
             orders = MentorOrder.objects.filter(
                 active=True,
                 session=self
-            ).order_by('check_in', 'mentor__last_name')
+            ).order_by('check_in', 'mentor__user__last_name')
 
         return orders
 
@@ -439,18 +439,18 @@ class Meeting(models.Model):
                 orders = MeetingOrder.objects.filter(
                     active=True,
                     meeting=self
-                ).exclude(check_in=None).order_by('mentor__last_name')
+                ).exclude(check_in=None).order_by('mentor__user__last_name')
             else:
                 orders = MeetingOrder.objects.filter(
                     active=True,
                     meeting=self,
                     check_in=None
-                ).order_by('mentor__last_name')
+                ).order_by('mentor__user__last_name')
         else:
             orders = MeetingOrder.objects.filter(
                 active=True,
                 meeting=self
-            ).order_by('check_in', 'mentor__last_name')
+            ).order_by('check_in', 'mentor__user__last_name')
 
         return orders
 

--- a/coderdojochi/views.py
+++ b/coderdojochi/views.py
@@ -1331,7 +1331,7 @@ def session_check_in_mentors(request, session_id, template_name="session-check-i
         return HttpResponseRedirect(reverse('sessions'))
 
     session_obj = get_object_or_404(Session, id=session_id)
-    current_mentor_orders_checked_in = session_obj.get_current_meeting_orders(checked_in=True)
+    current_mentor_orders_checked_in = session_obj.get_current_mentor_orders(checked_in=True)
     mentors_checked_in = current_mentor_orders_checked_in.values('mentor')
 
     if request.method == 'POST':


### PR DESCRIPTION
When removing the first/last name from the Guardian and Mentor models,
some changes were missed.