### PR TITLE
Upgrade node and remove package from pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER CoderDojoChi
 RUN apt-get update \
   && apt-get install -y curl memcached python-memcache
 
-RUN curl -sL https://deb.nodesource.com/setup_5.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
 RUN apt-get install -y nodejs
 
 ENV DIR_BUILD /build

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,4 +31,3 @@ requests-oauthlib==0.6.1
 requests==2.9.1
 six==1.10.0
 sqlparse==0.1.19
-virtualenv==15.0.1


### PR DESCRIPTION
Upgrade node from 5.x to 6.x since 5.x is not supported anymore.

Removed virtualenv from requirement.txt since it's not used.