### PR TITLE
Feature: delete student

### DIFF
--- a/coderdojochi/static/js/cdc.js
+++ b/coderdojochi/static/js/cdc.js
@@ -11,15 +11,13 @@ var CDC = CDC || {};
 CDC.global = (function($, document, window, undefined) {
     'use strict';
 
-    // app global properties
-
-
     /* Public Methods _________________________________________________________________ */
 
     function init() {
 
-        $(function() {
-            $('[data-toggle="popover"]').popover();
+        $('[data-toggle="popover"]').popover({
+             html: true,
+             container: 'body'
         });
 
         // account for csrf in all ajax requests

--- a/coderdojochi/static/scss/_student.scss
+++ b/coderdojochi/static/scss/_student.scss
@@ -1,0 +1,8 @@
+.page-student-detail {
+    .delete-student {
+        display: block;
+        margin-top: 15px;
+        padding-left: 0;
+        color: red;
+    }
+} 

--- a/coderdojochi/static/scss/cdc.scss
+++ b/coderdojochi/static/scss/cdc.scss
@@ -682,11 +682,7 @@ a.icon-action {
 
 }
 
-// class-detail
 @import "_class-detail";
-
-// Mentors
 @import "_mentors";
-
-
-@import 'admin';
+@import "_students";
+@import "admin";

--- a/coderdojochi/templates/guardian/dojo.html
+++ b/coderdojochi/templates/guardian/dojo.html
@@ -35,6 +35,7 @@
                         <td class="hidden-xs">{% if student.medications %}Yes{% else %}No{% endif %}</td>
                         <td>
                             <a href="{% url 'student_detail' student.id %}" class="btn-cdc btn-cdc-sm">Edit Info</a>
+                            <button role="button" class="btn btn-danger" data-trigger="focus" data-placement="left" data-toggle="popover" data-title="Delete Student?" data-content='<form action="{% url 'student_detail' student.id %}" method="post"><input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}" /><input type="hidden" name="delete" value="true" /><button class="btn btn-danger">Yes, Delete</button></form>'><i class="fa fa-times"></i></button>
                         </td>
                     </tr>
                 {% endfor %}

--- a/coderdojochi/templates/student-detail.html
+++ b/coderdojochi/templates/student-detail.html
@@ -8,11 +8,13 @@
 
 {% block content %}
 <div class="container registration min-height">
-<h1><small><a href="{% url 'dojo' %}">Back</a></small> Edit Student Info</h1>
-<form action="" method="post">
-    {% csrf_token %}
-    {% bootstrap_form form %}
-    <button class="submit btn btn-success btn-lg">Update</button> &nbsp;<a href="{% url 'dojo' %}" class="btn-link">Cancel</a>
-</form>
+    <h1><small><a href="{% url 'dojo' %}">Back</a></small> Edit Student Info</h1>
+    <form action="" method="post">
+        {% csrf_token %}
+        {% bootstrap_form form %}
+        <button class="submit btn btn-success btn-lg">Update</button>&nbsp;
+        <a href="{% url 'dojo' %}" class="btn-link">Cancel</a>
+    </form>
+    <button role="button" class="btn-link delete-student" data-trigger="focus" data-placement="right" data-toggle="popover" data-title="Are you sure?" data-content='<form action="." method="post"><input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}" /><input type="hidden" name="delete" value="true" /><button class="btn btn-danger">Yes, Delete</button></form>'>Delete Student</button>
 </div>
 {% endblock %}

--- a/coderdojochi/urls.py
+++ b/coderdojochi/urls.py
@@ -152,7 +152,6 @@ urlpatterns = [
         name='student_detail',
     ),
 
-
     # Classes
     # /classes/
     url(

--- a/coderdojochi/views.py
+++ b/coderdojochi/views.py
@@ -14,6 +14,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
+from django.core.exceptions import ObjectDoesNotExist
 from django.core.urlresolvers import reverse
 from django.core.mail import EmailMultiAlternatives, get_connection
 from django.db.models import (
@@ -1651,8 +1652,16 @@ def student_detail(
     access = True
 
     if request.user.role == 'guardian' and student_id:
-        student = get_object_or_404(Student, id=student_id)
-        guardian = get_object_or_404(Guardian, user=request.user)
+        # for the specific student redirect to admin page
+        try:
+            student = Student.objects.get(id=student_id, is_active=True)
+        except ObjectDoesNotExist:
+            return redirect('dojo')
+
+        try:
+            guardian = Guardian.objects.get(user=request.user, is_active=True)
+        except ObjectDoesNotExist:
+            return redirect('dojo')
 
         if not student.guardian == guardian:
             access = False

--- a/coderdojochi/views.py
+++ b/coderdojochi/views.py
@@ -1678,6 +1678,18 @@ def student_detail(
         )
 
     if request.method == 'POST':
+        if 'delete' in request.POST:
+            student.is_active = False
+            student.save()
+            messages.success(
+                request,
+                'Student "{} {}" Deleted.'.format(
+                    student.first_name,
+                    student.last_name
+                )
+            )
+            return redirect('dojo')
+
         form = StudentForm(request.POST, instance=student)
         if form.is_valid():
             form.save()

--- a/coderdojochi/views.py
+++ b/coderdojochi/views.py
@@ -1450,6 +1450,7 @@ def dojo_guardian(request, template_name='guardian/dojo.html'):
     )
 
     students = Student.objects.filter(
+        is_active = True,
         guardian=guardian
     )
 


### PR DESCRIPTION
Only show active students on guardian profile page
- On the guardian profile page (/dojo), only show the students that have the `is_active` boolean as True

Add redirect if student or guardian is not active
- On the student edit page (/student/ID/), added a redirect if the student is not active.
- On the student edit page (/student/ID/), added a redirect if the guardian (current user) is not active.  

Added ability for guardian to delete student
- When a "delete" action is called, set the `is_active` boolean for   Student to `False`  

Fixes #473 and #475 

