### PR TITLE
Fixed age calculations.

### DIFF
--- a/coderdojochi/models.py
+++ b/coderdojochi/models.py
@@ -270,13 +270,8 @@ class Student(models.Model):
         return is_registered
 
     def get_age(self, date=timezone.now()):
-        # today = timezone.now()
-        birthday = self.birthday
-        year_delta = date.year - birthday.year
-        return (
-            year_delta - (
-                (date.month, date.day) < (birthday.month, birthday.day)
-            )
+        return date.year - self.birthday.year - (
+            (date.month, date.day) < (self.birthday.month, self.birthday.day)
         )
     get_age.short_description = 'Age'
 
@@ -293,8 +288,8 @@ class Student(models.Model):
     get_clean_gender.short_description = 'Gender'
 
     # returns True if the student age is between min_age and max_age
-    def is_within_age_range(self, min_age, max_age):
-        age = self.get_age()
+    def is_within_age_range(self, min_age, max_age, date=timezone.now()):
+        age = self.get_age(date)
 
         if age >= min_age and age <= max_age:
             return True
@@ -822,22 +817,6 @@ class Order(models.Model):
             self.student.first_name,
             self.student.last_name,
             self.session.course.title
-        )
-
-    def get_student_age(self):
-        birthday = self.student.birthday
-        session_date = self.session.start_date
-        delta = session_date.year - birthday.year
-        return (
-            delta - (
-                (
-                    session_date.month,
-                    session_date.day
-                ) < (
-                    birthday.month,
-                    birthday.day
-                )
-            )
         )
 
 

--- a/coderdojochi/templates/dashboard/session-check-in.html
+++ b/coderdojochi/templates/dashboard/session-check-in.html
@@ -203,7 +203,7 @@
                                     <td class="vert-align">
                                       <strong>{{ order.student.first_name }}</strong> {{ order.student.last_name }}
                                     </td>
-                                    <td class="text-right vert-align">{{ order.student.get_age }}</td>
+                                    <td class="text-right vert-align">{{ order.student | student_age:session.start_date }}</td>
                                     <td>
                                         {% if active_session %}
                                             <input type="text" name="order_alternate_guardian" class="form-control" value="{% if order.alternate_guardian %}{{ order.alternate_guardian }}{% else %}{{ order.guardian.user.first_name }} {{ order.guardian.user.last_name }}{% endif %}">
@@ -268,7 +268,7 @@
                             <td>
                               <strong>{{ order.student.first_name }}</strong> {{ order.student.last_name }}
                             </td>
-                            <td class="text-right">{{ order.student.get_age }}</td>
+                            <td class="text-right">{{ order.student | student_age:session.start_date }}</td>
                             <td>{{ order.guardian.user.first_name }} {{ order.guardian.user.last_name }}</td>
                             <td class="text-right">{{ order.updated_at }}</td>
                             <td class="text-right">{{ order.num_attended }}</td>
@@ -306,7 +306,7 @@
                             <td>
                               <strong>{{ order.student.first_name }}</strong> {{ order.student.last_name }}
                             </td>
-                            <td class="text-right">{{ order.student.get_age }}</td>
+                            <td class="text-right">{{ order.student | student_age:session.start_date }}</td>
                             <td>{{ order.guardian.user.first_name }} {{ order.guardian.user.last_name }}</td>
                             <td class="text-right">{{ order.updated_at }}</td>
                             <td class="text-right">{{ order.num_attended }}</td>

--- a/coderdojochi/templates/dashboard/session-stats.html
+++ b/coderdojochi/templates/dashboard/session-stats.html
@@ -112,7 +112,7 @@
                         <input type="hidden" name="order_id" value="{{ order.id }}">
                         <td>{{ order.student.last_name }}, {{ order.student.first_name }}</td>
                         <td>{% if order.alternate_guardian %}{{ order.alternate_guardian }}{% else %}{{ order.guardian.user.first_name }} {{ order.guardian.user.last_name }}{% endif %}</td>
-                        <td>{{ order.get_student_age }}</td>
+                        <td>{{ order.student | student_age:session.start_date }}</td>
                         <td>{{ order.student.gender }}</td>
                         {% if order.check_in %}
                         <td>{{ order.check_in|time }}</td>

--- a/coderdojochi/templatetags/coderdojochi_extras.py
+++ b/coderdojochi/templatetags/coderdojochi_extras.py
@@ -55,7 +55,8 @@ def student_register_link(context, student, session):
     elif (
         not student.is_within_age_range(
             session.min_age_limitation,
-            session.max_age_limitation
+            session.max_age_limitation,
+            session.start_date
         ) or
         not student.is_within_gender_limitation(
             session.gender_limitation
@@ -68,7 +69,8 @@ def student_register_link(context, student, session):
         if (
             not student.is_within_age_range(
                 session.min_age_limitation,
-                session.max_age_limitation
+                session.max_age_limitation,
+                session.start_date
             ) and
             not student.is_within_gender_limitation(
                 session.gender_limitation
@@ -88,7 +90,8 @@ def student_register_link(context, student, session):
         elif (
             not student.is_within_age_range(
                 session.min_age_limitation,
-                session.max_age_limitation
+                session.max_age_limitation,
+                session.start_date
             )
         ):
             button_href = '''
@@ -124,3 +127,8 @@ def student_register_link(context, student, session):
     )
 
     return Template(form).render(context)
+
+
+@register.filter
+def student_age(student, date):
+    return student.get_age(date)

--- a/coderdojochi/views.py
+++ b/coderdojochi/views.py
@@ -655,7 +655,8 @@ def session_sign_up(
         if (
             not student.is_within_age_range(
                 session_obj.min_age_limitation,
-                session_obj.max_age_limitation
+                session_obj.max_age_limitation,
+                session_obj.start_date
             )
         ):
             messages.error(
@@ -1953,7 +1954,7 @@ def cdc_admin(request, template_name="admin.html"):
     # Ages
     ages = sorted(
         list(
-            e.student.get_age() for e in total_checked_in_orders
+            e.student.get_age(e.session.start_date) for e in total_checked_in_orders
         )
     )
     age_count = sorted(
@@ -2043,8 +2044,7 @@ def session_stats(request, session_id, template_name="session-stats.html"):
     # Ages
     ages = sorted(
         list(
-            e.student.get_age()
-            for e in session_obj.get_current_orders()
+            e.student.get_age(e.session.start_date) for e in session_obj.get_current_orders()
         )
     )
 
@@ -2062,7 +2062,7 @@ def session_stats(request, session_id, template_name="session-stats.html"):
     if current_orders_checked_in:
         student_ages = []
         for order in current_orders_checked_in:
-            student_ages.append(order.get_student_age())
+            student_ages.append(order.student.get_age(order.session.start_date))
 
         average_age = (
             reduce(
@@ -2201,7 +2201,7 @@ def session_check_in(
     # Ages
     ages = sorted(
         list(
-            e.get_student_age() for e in active_orders
+            e.student.get_age(e.session.start_date) for e in active_orders
         )
     )
 


### PR DESCRIPTION
The student's age should be calculated compared to the date of a session
or the current date.

On the guardian profile page, the student's age should be calculated in
relation of today's date.

On session or order pages, the age should be calculated based on the
session's start date. This should allow students who will turn a certain
age by the time of a session to be able to sign up.

Fixes #488