### PR TITLE
Fixes 400s and adds exception handler middleware for better logging

### DIFF
--- a/coderdojochi/middleware.py
+++ b/coderdojochi/middleware.py
@@ -1,0 +1,20 @@
+from django.conf import settings
+from django.shortcuts import render
+import logging
+import traceback
+from urllib3.exceptions import HTTPError
+
+
+logger = logging.getLogger(__name__)
+
+
+class HandleExceptionMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        return self.get_response(request)
+
+    def process_exception(self, request, exception):
+        logger.exception(traceback.format_exc(limit=3))
+        return render(request, '500.html')

--- a/coderdojochi/settings.py
+++ b/coderdojochi/settings.py
@@ -105,6 +105,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'coderdojochi.middleware.HandleExceptionMiddleware',
 ]
 
 ROOT_URLCONF = 'coderdojochi.urls'

--- a/coderdojochi/templates/account/email/_allauth-email-base.html
+++ b/coderdojochi/templates/account/email/_allauth-email-base.html
@@ -2,7 +2,7 @@
 
 {% load static %}
 
-{% block header_image %}<a href="https://{{ current_site.domain }}"><img alt="" border="0" id="headerImage" src="{% static '/images/coderdojochi_600x300_transparent.png' %}"></a>{% endblock header_image %}
+{% block header_image %}<a href="https://{{ current_site.domain }}"><img alt="" border="0" id="headerImage" src="{% static 'images/coderdojochi_600x300_transparent.png' %}"></a>{% endblock header_image %}
 
 {% block subject %}{% block child_subject %}{% endblock %}{% endblock %}
 {% block preheader %}{% block child_preheader %}{% endblock %}{% endblock %}


### PR DESCRIPTION
After adding the `HandleExceptionMiddleware` I finally saw an error coming from the register page:
```
django.core.exceptions.SuspiciousOperation: Attempted access to '/images/coderdojochi_600x300_transparent.png' denied.
```

There were 3 references to that file. One of those three had a preceding slash in the url. Removing that slash got rid of the error. Voila!

