### PR TITLE
Fixes non-string values in template replacement for SendGrid

### DIFF
--- a/coderdojochi/util.py
+++ b/coderdojochi/util.py
@@ -61,8 +61,8 @@ def email(
     merge_field_format = "*|{}|*"
     final_merge_global_data = {}
     for key, val in merge_global_data.items():
-        if val is not None and merge_field_format.format(key) in body:
-            final_merge_global_data[key] = val
+        if merge_field_format.format(key) in body:
+            final_merge_global_data[key] = "" if val == None else str(val)
 
     msg = AnymailMessage(
         subject=subject,
@@ -73,7 +73,8 @@ def email(
         merge_data=merge_data,
         merge_global_data=final_merge_global_data,
         esp_extra={
-            'merge_field_format': merge_field_format
+            'merge_field_format': merge_field_format,
+            'categories': [template_name],
         },
     )
 


### PR DESCRIPTION
When testing on Postman, I removed every field and added them back one at a time until I saw a 400. When I added a field that was not a string (like current_year), it finally freaked out. I confirmed the guardian and mentor confirmation email sent.